### PR TITLE
Introduce the repo manifest xml files

### DIFF
--- a/common-android14-6.1-override.xml
+++ b/common-android14-6.1-override.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="common-modules/xen-virtual-device" name="xen-troops/android_kernel_xen-virtual-device" remote="github" revision="common-android14-6.1-xenvm-trout-main" />
+</manifest>

--- a/common-android14-6.1.xml
+++ b/common-android14-6.1.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <superproject name="kernel/superproject" remote="aosp" revision="common-android14-6.1" />
+  <project path="build/kernel" name="kernel/build" revision="a1ad84bfd51f3c17eb1c18a42cff495a6cdf33d0" >
+    <linkfile src="kleaf/bazel.sh" dest="tools/bazel" />
+    <linkfile src="kleaf/bazel.WORKSPACE" dest="WORKSPACE" />
+    <linkfile src="build.sh" dest="build/build.sh" />
+    <linkfile src="build_abi.sh" dest="build/build_abi.sh" />
+    <linkfile src="build_test.sh" dest="build/build_test.sh" />
+    <linkfile src="build_utils.sh" dest="build/build_utils.sh" />
+    <linkfile src="config.sh" dest="build/config.sh" />
+    <linkfile src="envsetup.sh" dest="build/envsetup.sh" />
+    <linkfile src="_setup_env.sh" dest="build/_setup_env.sh" />
+    <linkfile src="multi-switcher.sh" dest="build/multi-switcher.sh" />
+    <linkfile src="abi" dest="build/abi" />
+    <linkfile src="static_analysis" dest="build/static_analysis" />
+  </project>
+  <project path="common" name="kernel/common" revision="80b6086d4e51480c53507a7eb497576957353f8a" >
+    <linkfile src="." dest=".source_date_epoch_dir" />
+  </project>
+  <project path="kernel/tests" name="kernel/tests" revision="b54ac65ca3128bb37264305d701d1c4b7bdf41ce" />
+  <project path="kernel/configs" name="kernel/configs" revision="cc3c9e7cef535c48c1cde0dc6d3aa206860e182e" />
+  <project path="common-modules/virtual-device" name="kernel/common-modules/virtual-device" revision="6c77ccb7fb41de51e25b5270b51d967f07213a10" />
+  <project path="prebuilts/clang/host/linux-x86" name="platform/prebuilts/clang/host/linux-x86" clone-depth="1" revision="12cd8a5633acf5e7f2c22e26a282574cfcfac37b" />
+  <project path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8" name="platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8" clone-depth="1" revision="f7b0d5b0ee369864d5ac3e96ae24ec9e2b6a52da" />
+  <project path="prebuilts/build-tools" name="platform/prebuilts/build-tools" clone-depth="1" revision="1e5c9b51126c4a5ec43a8e0299c044d337e376ae" />
+  <project path="prebuilts/clang-tools" name="platform/prebuilts/clang-tools" clone-depth="1" revision="a3a202692b2456629bf34eb3dcbe00a938250f0c" />
+  <project path="prebuilts/kernel-build-tools" name="kernel/prebuilts/build-tools" clone-depth="1" revision="2e789fde1a18fe6554d5288d52ae6cad6bea57b2" />
+  <project path="tools/mkbootimg" name="platform/system/tools/mkbootimg" revision="2680066d0844544b3e78d6022cd21321d31837c3" />
+  <project path="prebuilts/bazel/linux-x86_64" name="platform/prebuilts/bazel/linux-x86_64" clone-depth="1" revision="4fdb9395071ff22118311d434d697c2b6fd887b4" />
+  <project path="prebuilts/jdk/jdk11" name="platform/prebuilts/jdk/jdk11" clone-depth="1" revision="491e6aa056676f29c4541f71bd738e4e876e4ba2" />
+  <project path="prebuilts/ndk-r23" name="toolchain/prebuilts/ndk/r23" clone-depth="1" revision="19ac7e4eded12adb99d4f613490dde6dd0e72664" />
+  <project path="external/bazel-skylib" name="platform/external/bazel-skylib" revision="f998e5dc13c03f0eae9e373263d3afff0932c738" />
+  <project path="build/bazel_common_rules" name="platform/build/bazel_common_rules" revision="707b2c5fe3d0d7d934a93e00a8a4062e83557831" />
+  <project path="external/stardoc" name="platform/external/stardoc" revision="e83f522ee95419e55d2c5654aa6e0143beeef595" />
+  <project path="external/python/absl-py" name="platform/external/python/absl-py" revision="393d0b1e3f0fea3e95944a2fd3282cc9f76d4f14" />
+</manifest>

--- a/default.xml
+++ b/default.xml
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote  name="aosp" fetch="https://android.googlesource.com/" />
-  <remote  name="xt" fetch="https://github.com/xen-troops/" />
-  <remote  name="epam" fetch="ssh://git@gitpct.epam.com/epmd-aepr/" />
-
-  <default revision="master-kernel-build-2021" remote="aosp" sync-j="4" />
-
-  <superproject name="kernel/superproject" remote="aosp"/>
-
-  <project path="build" name="kernel/build" />
-  <project path="common" name="linux" remote="xt" revision="android12-5.4-xt-master" />
-  <project path="hikey-modules" name="kernel/hikey-modules" revision="android-5.4" />
-  <project path="kernel/tests" name="kernel/tests" />
-  <project path="kernel/configs" name="kernel/configs" />
-  <project path="common-modules/virtual-device" name="kernel/common-modules/virtual-device" revision="android12-5.4" />
-  <project path="prebuilts-master/clang/host/linux-x86" name="platform/prebuilts/clang/host/linux-x86" clone-depth="1" />
-  <project path="prebuilts-master/gcc/linux-x86/aarch64" name="android_prebuilds_gcc_linuxx86_aarch64" remote="xt" revision="gcc-arm-10.2-2020.11" clone-depth="1" />
-  <project path="prebuilts/build-tools" name="platform/prebuilts/build-tools" clone-depth="1" />
-  <project path="prebuilts/kernel-build-tools" name="kernel/prebuilts/build-tools" clone-depth="1" />
-  <project path="tools/mkbootimg" name="platform/system/tools/mkbootimg" />
-  <project path="imagination/rogue_km" name="pvr_km_vgpu_img" groups="notdefault" remote="epam" revision="1.11-5375571-7.1.0-android-12-xt-5.4">
-    <linkfile src="standalone/Makefile" dest="imagination/Makefile" />
-  </project>
+  <remote name="github" fetch="ssh://git@github.com"/>
+  <remote  name="aosp" fetch="https://android.googlesource.com/" review="https://android-review.googlesource.com/" />
+  <default revision="master" remote="aosp" sync-j="4" />
+  <include name="common-android14-6.1.xml" />
+  <include name="common-android14-6.1-override.xml" />
 </manifest>


### PR DESCRIPTION
The Android R&D, which we are building should use the common-android14-6.1 version of the Android kernel. That one is built with the help of Bazel and repo. Repo is based on usage of the xml manifest files.

This patch is introducing several xml repo manifest files, which contain links to all required projects that are needed to build the Android kernel.

That includes the xen-virtual-device repository, which is located in xen-troops and is introducing the Xen-specific Bazel configuration.

The logic behind the introduced files is the following one:

- default.xml - entry point to include other files and locate the common declarations
- common-android14-6.1.xml - the original Android kernel repo manifest, which was fetched from its original location
- common-android14-6.1-override.xml - anything we add on top of the original manifest