### PR TITLE
Change kernel source repository protocol.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote name="github" fetch="ssh://git@github.com"/>
+  <remote name="github" fetch="https://github.com"/>
   <remote  name="aosp" fetch="https://android.googlesource.com/" review="https://android-review.googlesource.com/" />
   <default revision="master" remote="aosp" sync-j="4" />
   <include name="common-android14-6.1.xml" />


### PR DESCRIPTION
Switch to using HTTPS instead of SSH. This will allow users without GitHub registration to clone the repository.