### PR TITLE
Fix incomplete manifest

### DIFF
--- a/common-android14-6.1.xml
+++ b/common-android14-6.1.xml
@@ -8,6 +8,7 @@
     <linkfile src="build_test.sh" dest="build/build_test.sh" />
     <linkfile src="config.sh" dest="build/config.sh" />
   </project>
+  <project path="common" name="kernel/common" revision="4bcafa4d00932c69559ed8af28fb6813a1be9097" />
   <project name="kernel/configs" revision="95121b20443b1b3fb62b80651d05ffdacb4d55c2" upstream="main" dest-branch="main"/>
   <project name="kernel/tests" revision="bb56a7198b3e40c17fc91e6153352dadab81ba45" upstream="main" dest-branch="main">
     <linkfile src="tools/run_test_only.sh" dest="run_test_only.sh" />


### PR DESCRIPTION
Due to integration error kernel/common disappeared from manifest. FIXES: 88fde711b5c2c379cbdb361c63f7653bd6352aee

Change-Id: I3c6db2a103bacc6fccd1bca1033d15c35c94305e