### PR TITLE
proprietary.xml: update display framework module revision to 4.31

### DIFF
--- a/proprietary.xml
+++ b/proprietary.xml
@@ -2,5 +2,5 @@
 <manifest>
   <remote name="rs" fetch="https://partnergitlab.renesas.solutions/"/>
   <project path="modules/imagination/ddk" name="x5h-fusion-poc/ddk-km" remote="rs" revision="24.2_6923851-android-15-main" />
-  <project path="modules/renesas/disfwk_fe" name="x5h-fusion-poc/disfwk_fe" remote="rs" revision="android15-main" />
+  <project path="modules/renesas/disfwk_fe" name="x5h-fusion-poc/disfwk_fe" remote="rs" revision="disfwk_multiguest_4.31" />
 </manifest>


### PR DESCRIPTION
DisFWK frontend kernel module need to be updated to successfully switch to a new version of Renesas SDK.