### PR TITLE
Update ddk 26.1 rtm2 and pcie

### DIFF
--- a/common-android16-6.18-override.xml
+++ b/common-android16-6.18-override.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <remote name="github" fetch="https://github.com"/>
-  <project path="common-modules/xen-virtual-device" name="xen-troops/android_kernel_xen-virtual-device" remote="github" revision="b4e20965fa26cae6e56aba99fb3469d0c45f10f4" /> <!-- common-android17-6.18-xenvm-trout-ih-main -->
+  <project path="common-modules/xen-virtual-device" name="xen-troops/android_kernel_xen-virtual-device" remote="github" revision="220aa59516f185dbaee9c50853bb9bc085fe26d9" /> <!-- common-android17-6.18-xenvm-trout-ih-main -->
 </manifest>

--- a/proprietary.xml
+++ b/proprietary.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <remote name="rs" fetch="https://partnergitlab.renesas.solutions/"/>
-  <project path="modules/imagination/ddk" name="x5h-fusion-poc/ddk-km" remote="rs" revision="939e551d315ff2b78f724a2014eb17b41d5722e4" /> <!-- 25.1_6794074-android-17-main -->
+  <project path="modules/imagination/ddk" name="x5h-fusion-poc/ddk-km" remote="rs" revision="6b3ee9bf8c48853a6cb2bba72703758ab84a41f9" /> <!-- 26.1_7036548_RTM2-android-17-main -->
   <project path="modules/renesas/disfwk_fe" name="x5h-fusion-poc/disfwk_fe" remote="rs" revision="7d51259b29cffc46c56466c02b71b69b69785026" /> <!-- disfwk_multiguest_4.31 -->
   <project path="modules/renesas/rcar-mfis" name="x5h-fusion-poc/rcar_mfis" remote="rs" revision="5d83bd8ee9c42c8c4903f8100aef9f646102c52a" /> <!-- disfwk_multiguest_4.31 -->
   <project path="modules/renesas/rcar_gen5_rproc" name="x5h-fusion-poc/rcar_gen5_rproc" remote="rs" revision="b7cfbda865a645fd18629396fdecfef049a29a00" /> <!-- disfwk_multiguest_4.31 -->

--- a/proprietary.xml
+++ b/proprietary.xml
@@ -5,6 +5,6 @@
   <project path="modules/renesas/disfwk_fe" name="x5h-fusion-poc/disfwk_fe" remote="rs" revision="7d51259b29cffc46c56466c02b71b69b69785026" /> <!-- disfwk_multiguest_4.31 -->
   <project path="modules/renesas/rcar-mfis" name="x5h-fusion-poc/rcar_mfis" remote="rs" revision="5d83bd8ee9c42c8c4903f8100aef9f646102c52a" /> <!-- disfwk_multiguest_4.31 -->
   <project path="modules/renesas/rcar_gen5_rproc" name="x5h-fusion-poc/rcar_gen5_rproc" remote="rs" revision="b7cfbda865a645fd18629396fdecfef049a29a00" /> <!-- disfwk_multiguest_4.31 -->
-  <project path="modules/renesas/pcie6_rcar_gen5_host" name="x5h-fusion-poc/rcar_pcie6_host" remote="rs" revision="2435331ed8be7fc4ae288b7f4b28c00f7322d415" /> <!-- PCIe6 BSP kernel 6.12.68 -->
+  <project path="modules/renesas/pcie6_rcar_gen5_host" name="x5h-fusion-poc/rcar_pcie6_host" remote="rs" revision="2c6f2415ebebc7b4fee54ee9da2208a71afcc189" /> <!-- sdk-4.36_6.18.26 -->
   <project path="modules/renesas/camfwk_fe" name="x5h-fusion-poc/camfwk_fe" remote="rs" revision="de3b9b2de70fbe6c9b6dcadc372c0f7b28876af6" /> <!-- sdk-4.31-multiguest -->
 </manifest>


### PR DESCRIPTION
Update kernel manifest revisions to enable PCIe support and integrate DDK 26.1_7036548_RTM2.